### PR TITLE
Added stats for GT 2024 game

### DIFF
--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -548,20 +548,75 @@
     },
     "opponentId": "GT",
     "espnGameId": 401628982,
+    "highlightsYouTubeVideoId": "BkD7P9XLBMA",
     "records": {
       "home": {
-        "overall": "2-3",
+        "overall": "2-4",
         "home": "2-2",
-        "away": "0-1",
+        "away": "0-2",
         "neutral": "0-0"
       },
       "away": {
-        "overall": "5-1",
+        "overall": "6-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "0-0"
+        "neutral": "1-0"
       }
     },
+    "headCoach": "Marcus Freeman",
+    "stats": {
+      "away": {
+        "firstDowns": 23,
+        "thirdDownAttempts": 12,
+        "thirdDownConversions": 4,
+        "fourthDownAttempts": 4,
+        "fourthDownConversions": 3,
+        "totalYards": 385,
+        "passYards": 217,
+        "passCompletions": 21,
+        "passAttempts": 30,
+        "yardsPerPass": 7.2,
+        "interceptionsThrown": 1,
+        "rushYards": 168,
+        "rushAttempts": 39,
+        "yardsPerRush": 4.3,
+        "penalties": 5,
+        "penaltyYards": 37,
+        "possession": "35:45",
+        "fumblesLost": 0,
+        "fumbles": 0
+      },
+      "home": {
+        "firstDowns": 18,
+        "thirdDownAttempts": 14,
+        "thirdDownConversions": 4,
+        "fourthDownAttempts": 5,
+        "fourthDownConversions": 3,
+        "totalYards": 333,
+        "passYards": 269,
+        "passCompletions": 20,
+        "passAttempts": 38,
+        "yardsPerPass": 7.1,
+        "interceptionsThrown": 2,
+        "rushYards": 64,
+        "rushAttempts": 29,
+        "yardsPerRush": 2.2,
+        "penalties": 5,
+        "penaltyYards": 25,
+        "possession": "24:15",
+        "fumblesLost": 0,
+        "fumbles": 1
+      }
+    },
+    "score": {
+      "home": 13,
+      "away": 31
+    },
+    "linescore": {
+      "away": [0, 14, 7, 10],
+      "home": [7, 0, 0, 6]
+    },
+    "result": "W",
     "rankings": {
       "away": {
         "ap": 12,
@@ -584,16 +639,16 @@
     "espnGameId": 401628983,
     "records": {
       "home": {
-        "overall": "5-0",
-        "home": "3-0",
+        "overall": "6-0",
+        "home": "4-0",
         "away": "2-0",
         "neutral": "0-0"
       },
       "away": {
-        "overall": "5-1",
+        "overall": "6-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "0-0"
+        "neutral": "1-0"
       }
     },
     "rankings": {
@@ -620,15 +675,15 @@
     "espnGameId": 401628984,
     "records": {
       "home": {
-        "overall": "5-1",
+        "overall": "6-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "0-0"
+        "neutral": "1-0"
       },
       "away": {
-        "overall": "1-5",
+        "overall": "1-6",
         "home": "1-3",
-        "away": "0-1",
+        "away": "0-2",
         "neutral": "0-1"
       }
     },
@@ -653,15 +708,15 @@
     "espnGameId": 401628985,
     "records": {
       "home": {
-        "overall": "5-1",
+        "overall": "6-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "0-0"
+        "neutral": "1-0"
       },
       "away": {
-        "overall": "4-2",
+        "overall": "4-3",
         "home": "2-2",
-        "away": "2-0",
+        "away": "2-1",
         "neutral": "0-0"
       }
     },
@@ -688,16 +743,16 @@
     "espnGameId": 401640959,
     "records": {
       "home": {
-        "overall": "6-0",
-        "home": "3-0",
+        "overall": "7-0",
+        "home": "4-0",
         "away": "3-0",
         "neutral": "0-0"
       },
       "away": {
-        "overall": "5-1",
+        "overall": "6-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "0-0"
+        "neutral": "1-0"
       }
     },
     "rankings": {
@@ -731,10 +786,10 @@
         "neutral": "1-0"
       },
       "away": {
-        "overall": "5-1",
+        "overall": "6-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "0-0"
+        "neutral": "1-0"
       }
     },
     "rankings": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new game entries for the 2024 season, including matchups against Georgia Tech, Navy, FSU, UVA, Army, and USC.
	- Updated game records and statistics to reflect current performance and standings.
- **Bug Fixes**
	- Corrected overall records and rankings for multiple games.
	- Adjusted game statistics, including first downs and total yards.
- **Enhancements**
	- Modified scores and linescores for various games to ensure accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->