### PR TITLE
Added updated polls from 2024-10-20

### DIFF
--- a/data/polls/2024.json
+++ b/data/polls/2024.json
@@ -1039,6 +1039,136 @@
           "previousRanking": "NR"
         }
       }
+    },
+    {
+      "date": "2024-10-20",
+      "teams": {
+        "Oregon": {
+          "record": "7-0",
+          "ranking": 1,
+          "previousRanking": 2
+        },
+        "Georgia": {
+          "record": "6-1",
+          "ranking": 2,
+          "previousRanking": 5
+        },
+        "Penn State": {
+          "record": "6-0",
+          "ranking": 3,
+          "previousRanking": 3
+        },
+        "Ohio State": {
+          "record": "5-1",
+          "ranking": 4,
+          "previousRanking": 4
+        },
+        "Texas": {
+          "record": "6-1",
+          "ranking": 5,
+          "previousRanking": 1
+        },
+        "Miami": {
+          "record": "7-0",
+          "ranking": 6,
+          "previousRanking": 6
+        },
+        "Tennessee": {
+          "record": "6-1",
+          "ranking": 7,
+          "previousRanking": 11
+        },
+        "LSU": {
+          "record": "6-1",
+          "ranking": 8,
+          "previousRanking": 8
+        },
+        "Clemson": {
+          "record": "6-1",
+          "ranking": 9,
+          "previousRanking": 10
+        },
+        "Iowa State": {
+          "record": "7-0",
+          "ranking": 10,
+          "previousRanking": 9
+        },
+        "BYU": {
+          "record": "7-0",
+          "ranking": 11,
+          "previousRanking": 13
+        },
+        "Notre Dame": {
+          "record": "6-1",
+          "ranking": 12,
+          "previousRanking": 12
+        },
+        "Indiana": {
+          "record": "7-0",
+          "ranking": 13,
+          "previousRanking": 16
+        },
+        "Texas A&M": {
+          "record": "6-1",
+          "ranking": 14,
+          "previousRanking": 14
+        },
+        "Alabama": {
+          "record": "5-2",
+          "ranking": 15,
+          "previousRanking": 7
+        },
+        "Kansas State": {
+          "record": "6-1",
+          "ranking": 16,
+          "previousRanking": 17
+        },
+        "Boise State": {
+          "record": "5-1",
+          "ranking": 17,
+          "previousRanking": 15
+        },
+        "Ole Miss": {
+          "record": "5-2",
+          "ranking": 18,
+          "previousRanking": 18
+        },
+        "Pittsburgh": {
+          "record": "6-0",
+          "ranking": 19,
+          "previousRanking": 20
+        },
+        "Illinois": {
+          "record": "6-1",
+          "ranking": 20,
+          "previousRanking": 22
+        },
+        "Missouri": {
+          "record": "6-1",
+          "ranking": 21,
+          "previousRanking": 19
+        },
+        "Southern Methodist": {
+          "record": "6-1",
+          "ranking": 22,
+          "previousRanking": 21
+        },
+        "Army": {
+          "record": "7-0",
+          "ranking": 23,
+          "previousRanking": 23
+        },
+        "Navy": {
+          "record": "6-0",
+          "ranking": 24,
+          "previousRanking": 25
+        },
+        "Vanderbilt": {
+          "record": "5-2",
+          "ranking": 25,
+          "previousRanking": "NR"
+        }
+      }
     }
   ],
   "coaches": [
@@ -2077,6 +2207,136 @@
         },
         "Nebraska": {
           "record": "5-1",
+          "ranking": 25,
+          "previousRanking": "NR"
+        }
+      }
+    },
+    {
+      "date": "2024-10-20",
+      "teams": {
+        "Oregon": {
+          "record": "7-0",
+          "ranking": 1,
+          "previousRanking": 2
+        },
+        "Georgia": {
+          "record": "6-1",
+          "ranking": 2,
+          "previousRanking": 4
+        },
+        "Penn State": {
+          "record": "6-0",
+          "ranking": 3,
+          "previousRanking": 3
+        },
+        "Ohio State": {
+          "record": "5-1",
+          "ranking": 4,
+          "previousRanking": 5
+        },
+        "Miami": {
+          "record": "7-0",
+          "ranking": 5,
+          "previousRanking": 6
+        },
+        "Texas": {
+          "record": "6-1",
+          "ranking": 6,
+          "previousRanking": 1
+        },
+        "LSU": {
+          "record": "6-1",
+          "ranking": 7,
+          "previousRanking": 8
+        },
+        "Tennessee": {
+          "record": "6-1",
+          "ranking": 8,
+          "previousRanking": 10
+        },
+        "Clemson": {
+          "record": "6-1",
+          "ranking": 9,
+          "previousRanking": 9
+        },
+        "Iowa State": {
+          "record": "7-0",
+          "ranking": 10,
+          "previousRanking": 12
+        },
+        "Notre Dame": {
+          "record": "6-1",
+          "ranking": 11,
+          "previousRanking": 11
+        },
+        "BYU": {
+          "record": "7-0",
+          "ranking": 12,
+          "previousRanking": 13
+        },
+        "Indiana": {
+          "record": "7-0",
+          "ranking": 13,
+          "previousRanking": 18
+        },
+        "Texas A&M": {
+          "record": "6-1",
+          "ranking": 14,
+          "previousRanking": 14
+        },
+        "Alabama": {
+          "record": "5-2",
+          "ranking": 15,
+          "previousRanking": 7
+        },
+        "Kansas State": {
+          "record": "6-1",
+          "ranking": 16,
+          "previousRanking": 17
+        },
+        "Missouri": {
+          "record": "6-1",
+          "ranking": 17,
+          "previousRanking": 16
+        },
+        "Ole Miss": {
+          "record": "5-2",
+          "ranking": 18,
+          "previousRanking": 15
+        },
+        "Boise State": {
+          "record": "5-1",
+          "ranking": 19,
+          "previousRanking": 19
+        },
+        "Pittsburgh": {
+          "record": "6-0",
+          "ranking": 20,
+          "previousRanking": 20
+        },
+        "Illinois": {
+          "record": "6-1",
+          "ranking": 21,
+          "previousRanking": 21
+        },
+        "Southern Methodist": {
+          "record": "6-1",
+          "ranking": 22,
+          "previousRanking": 23
+        },
+        "Army": {
+          "record": "7-0",
+          "ranking": 23,
+          "previousRanking": 24
+        },
+        "Navy": {
+          "record": "6-0",
+          "ranking": 24,
+          "previousRanking": "NR"
+        },
+        "Vanderbilt": {
+          "record": "5-2",
           "ranking": 25,
           "previousRanking": "NR"
         }

--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -628,7 +628,7 @@
     "isHomeGame": false,
     "isNeutralSiteGame": true,
     "fullDate": "Sat Oct 26 2024 12:00:00 GMT-0400",
-    "coverage": "TBD",
+    "coverage": "ABC",
     "location": {
       "city": "East Rutherford",
       "state": "NJ",
@@ -657,7 +657,8 @@
         "coaches": 11
       },
       "home": {
-        "ap": 25
+        "ap": 24,
+        "coaches": 24
       }
     }
   },
@@ -762,7 +763,7 @@
       },
       "home": {
         "ap": 23,
-        "coaches": 24
+        "coaches": 23
       }
     }
   },
@@ -780,9 +781,9 @@
     "espnGameId": 401628571,
     "records": {
       "home": {
-        "overall": "3-3",
+        "overall": "3-4",
         "home": "2-1",
-        "away": "0-2",
+        "away": "0-3",
         "neutral": "1-0"
       },
       "away": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new college football rankings and records for October 20, 2024.
	- Updated game coverage details for October 26, 2024.
- **Bug Fixes**
	- Adjusted team records and rankings for specific matchups in the schedule.
	- Corrected coverage information for upcoming games.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->