### PR TITLE
Added 2024 NAVY stats

### DIFF
--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -637,12 +637,13 @@
     },
     "opponentId": "NAVY",
     "espnGameId": 401628983,
+    "highlightsYouTubeVideoId": "oqGo8IvZlRU",
     "records": {
       "home": {
-        "overall": "6-0",
+        "overall": "6-1",
         "home": "4-0",
         "away": "2-0",
-        "neutral": "0-0"
+        "neutral": "0-1"
       },
       "away": {
         "overall": "6-1",
@@ -651,6 +652,60 @@
         "neutral": "1-0"
       }
     },
+    "headCoach": "Marcus Freeman",
+    "stats": {
+      "away": {
+        "firstDowns": 20,
+        "thirdDownAttempts": 13,
+        "thirdDownConversions": 8,
+        "fourthDownAttempts": 1,
+        "fourthDownConversions": 1,
+        "totalYards": 466,
+        "passYards": 201,
+        "passCompletions": 15,
+        "passAttempts": 25,
+        "yardsPerPass": 8,
+        "interceptionsThrown": 0,
+        "rushYards": 265,
+        "rushAttempts": 40,
+        "yardsPerRush": 6.6,
+        "penalties": 9,
+        "penaltyYards": 80,
+        "possession": "30:29",
+        "fumblesLost": 0,
+        "fumbles": 0
+      },
+      "home": {
+        "firstDowns": 17,
+        "thirdDownAttempts": 11,
+        "thirdDownConversions": 4,
+        "fourthDownAttempts": 3,
+        "fourthDownConversions": 2,
+        "totalYards": 310,
+        "passYards": 88,
+        "passCompletions": 7,
+        "passAttempts": 14,
+        "yardsPerPass": 6.3,
+        "interceptionsThrown": 1,
+        "rushYards": 222,
+        "rushAttempts": 43,
+        "yardsPerRush": 5.2,
+        "penalties": 5,
+        "penaltyYards": 40,
+        "possession": "29:31",
+        "fumblesLost": 5,
+        "fumbles": 7
+      }
+    },
+    "score": {
+      "home": 14,
+      "away": 51
+    },
+    "linescore": {
+      "away": [14, 17, 13, 7],
+      "home": [0, 7, 7, 0]
+    },
+    "result": "W",
     "rankings": {
       "away": {
         "ap": 12,
@@ -781,8 +836,8 @@
     "espnGameId": 401628571,
     "records": {
       "home": {
-        "overall": "3-4",
-        "home": "2-1",
+        "overall": "4-4",
+        "home": "3-1",
         "away": "0-3",
         "neutral": "1-0"
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new game entries for the 2024 season against Navy and USC, including updated statistics.
	- Enhanced game details with YouTube video IDs for highlights.
- **Bug Fixes**
	- Corrected overall records for the home team in games against Navy and USC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->