### PR TITLE
Added polls from 2024-10-27

### DIFF
--- a/data/polls/2024.json
+++ b/data/polls/2024.json
@@ -1169,6 +1169,136 @@
           "previousRanking": "NR"
         }
       }
+    },
+    {
+      "date": "2024-10-27",
+      "teams": {
+        "Oregon": {
+          "record": "8-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Georgia": {
+          "record": "6-1",
+          "ranking": 2,
+          "previousRanking": 2
+        },
+        "Penn State": {
+          "record": "7-0",
+          "ranking": 3,
+          "previousRanking": 3
+        },
+        "Ohio State": {
+          "record": "6-1",
+          "ranking": 4,
+          "previousRanking": 4
+        },
+        "Miami": {
+          "record": "8-0",
+          "ranking": 5,
+          "previousRanking": 6
+        },
+        "Texas": {
+          "record": "7-1",
+          "ranking": 6,
+          "previousRanking": 5
+        },
+        "Tennessee": {
+          "record": "6-1",
+          "ranking": 7,
+          "previousRanking": 7
+        },
+        "Notre Dame": {
+          "record": "7-1",
+          "ranking": 8,
+          "previousRanking": 12
+        },
+        "BYU": {
+          "record": "8-0",
+          "ranking": 9,
+          "previousRanking": 11
+        },
+        "Texas A&M": {
+          "record": "7-1",
+          "ranking": 10,
+          "previousRanking": 14
+        },
+        "Clemson": {
+          "record": "6-1",
+          "ranking": 11,
+          "previousRanking": 9
+        },
+        "Iowa State": {
+          "record": "7-0",
+          "ranking": 11,
+          "previousRanking": 10
+        },
+        "Indiana": {
+          "record": "8-0",
+          "ranking": 13,
+          "previousRanking": 13
+        },
+        "Alabama": {
+          "record": "6-2",
+          "ranking": 14,
+          "previousRanking": 15
+        },
+        "Boise State": {
+          "record": "6-1",
+          "ranking": 15,
+          "previousRanking": 17
+        },
+        "LSU": {
+          "record": "6-2",
+          "ranking": 16,
+          "previousRanking": 8
+        },
+        "Kansas State": {
+          "record": "7-1",
+          "ranking": 17,
+          "previousRanking": 16
+        },
+        "Pittsburgh": {
+          "record": "7-0",
+          "ranking": 18,
+          "previousRanking": 19
+        },
+        "Ole Miss": {
+          "record": "6-2",
+          "ranking": 19,
+          "previousRanking": 18
+        },
+        "Southern Methodist": {
+          "record": "7-1",
+          "ranking": 20,
+          "previousRanking": 22
+        },
+        "Army": {
+          "record": "7-0",
+          "ranking": 21,
+          "previousRanking": 23
+        },
+        "Washington State": {
+          "record": "7-1",
+          "ranking": 22,
+          "previousRanking": "NR"
+        },
+        "Colorado": {
+          "record": "6-2",
+          "ranking": 23,
+          "previousRanking": "NR"
+        },
+        "Illinois": {
+          "record": "6-2",
+          "ranking": 24,
+          "previousRanking": 20
+        },
+        "Missouri": {
+          "record": "6-2",
+          "ranking": 25,
+          "previousRanking": 21
+        }
+      }
     }
   ],
   "coaches": [
@@ -2337,6 +2467,136 @@
         },
         "Vanderbilt": {
           "record": "5-2",
+          "ranking": 25,
+          "previousRanking": "NR"
+        }
+      }
+    },
+    {
+      "date": "2024-10-27",
+      "teams": {
+        "Oregon": {
+          "record": "8-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Georgia": {
+          "record": "6-1",
+          "ranking": 2,
+          "previousRanking": 2
+        },
+        "Penn State": {
+          "record": "7-0",
+          "ranking": 3,
+          "previousRanking": 3
+        },
+        "Ohio State": {
+          "record": "6-1",
+          "ranking": 4,
+          "previousRanking": 4
+        },
+        "Miami": {
+          "record": "8-0",
+          "ranking": 5,
+          "previousRanking": 5
+        },
+        "Texas": {
+          "record": "7-1",
+          "ranking": 6,
+          "previousRanking": 6
+        },
+        "Tennessee": {
+          "record": "6-1",
+          "ranking": 7,
+          "previousRanking": 8
+        },
+        "Clemson": {
+          "record": "6-1",
+          "ranking": 8,
+          "previousRanking": 9
+        },
+        "Notre Dame": {
+          "record": "7-1",
+          "ranking": 9,
+          "previousRanking": 11
+        },
+        "Iowa State": {
+          "record": "7-0",
+          "ranking": 10,
+          "previousRanking": 10
+        },
+        "Texas A&M": {
+          "record": "7-1",
+          "ranking": 11,
+          "previousRanking": 14
+        },
+        "BYU": {
+          "record": "8-0",
+          "ranking": 12,
+          "previousRanking": 12
+        },
+        "Indiana": {
+          "record": "8-0",
+          "ranking": 13,
+          "previousRanking": 13
+        },
+        "Alabama": {
+          "record": "6-2",
+          "ranking": 14,
+          "previousRanking": 15
+        },
+        "Kansas State": {
+          "record": "7-1",
+          "ranking": 15,
+          "previousRanking": 16
+        },
+        "LSU": {
+          "record": "6-2",
+          "ranking": 16,
+          "previousRanking": 7
+        },
+        "Pittsburgh": {
+          "record": "7-0",
+          "ranking": 17,
+          "previousRanking": 20
+        },
+        "Ole Miss": {
+          "record": "6-2",
+          "ranking": 18,
+          "previousRanking": 18
+        },
+        "Boise State": {
+          "record": "6-1",
+          "ranking": 19,
+          "previousRanking": 19
+        },
+        "Southern Methodist": {
+          "record": "7-1",
+          "ranking": 20,
+          "previousRanking": 22
+        },
+        "Army": {
+          "record": "7-0",
+          "ranking": 21,
+          "previousRanking": 23
+        },
+        "Washington State": {
+          "record": "7-1",
+          "ranking": 22,
+          "previousRanking": "NR"
+        },
+        "Missouri": {
+          "record": "6-2",
+          "ranking": 23,
+          "previousRanking": 17
+        },
+        "Illinois": {
+          "record": "6-2",
+          "ranking": 24,
+          "previousRanking": 21
+        },
+        "Memphis": {
+          "record": "7-1",
           "ranking": 25,
           "previousRanking": "NR"
         }

--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -637,7 +637,7 @@
     },
     "opponentId": "NAVY",
     "espnGameId": 401628983,
-    "highlightsYouTubeVideoId": "oqGo8IvZlRU",
+    "highlightsYouTubeVideoId": "F_O6FdBzH90",
     "records": {
       "home": {
         "overall": "6-1",

--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -551,9 +551,9 @@
     "highlightsYouTubeVideoId": "BkD7P9XLBMA",
     "records": {
       "home": {
-        "overall": "2-4",
+        "overall": "2-5",
         "home": "2-2",
-        "away": "0-2",
+        "away": "0-3",
         "neutral": "0-0"
       },
       "away": {
@@ -646,10 +646,10 @@
         "neutral": "0-1"
       },
       "away": {
-        "overall": "6-1",
+        "overall": "7-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "1-0"
+        "neutral": "2-0"
       }
     },
     "headCoach": "Marcus Freeman",
@@ -681,15 +681,15 @@
         "thirdDownConversions": 4,
         "fourthDownAttempts": 3,
         "fourthDownConversions": 2,
-        "totalYards": 310,
+        "totalYards": 312,
         "passYards": 88,
         "passCompletions": 7,
         "passAttempts": 14,
         "yardsPerPass": 6.3,
         "interceptionsThrown": 1,
-        "rushYards": 222,
-        "rushAttempts": 43,
-        "yardsPerRush": 5.2,
+        "rushYards": 224,
+        "rushAttempts": 42,
+        "yardsPerRush": 5.3,
         "penalties": 5,
         "penaltyYards": 40,
         "possession": "29:31",
@@ -731,22 +731,22 @@
     "espnGameId": 401628984,
     "records": {
       "home": {
-        "overall": "6-1",
+        "overall": "7-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "1-0"
+        "neutral": "2-0"
       },
       "away": {
-        "overall": "1-6",
+        "overall": "1-7",
         "home": "1-3",
-        "away": "0-2",
+        "away": "0-3",
         "neutral": "0-1"
       }
     },
     "rankings": {
       "home": {
-        "ap": 12,
-        "coaches": 11
+        "ap": 8,
+        "coaches": 9
       }
     }
   },
@@ -764,22 +764,22 @@
     "espnGameId": 401628985,
     "records": {
       "home": {
-        "overall": "6-1",
+        "overall": "7-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "1-0"
+        "neutral": "2-0"
       },
       "away": {
-        "overall": "4-3",
-        "home": "2-2",
+        "overall": "4-4",
+        "home": "2-3",
         "away": "2-1",
         "neutral": "0-0"
       }
     },
     "rankings": {
       "home": {
-        "ap": 12,
-        "coaches": 11
+        "ap": 8,
+        "coaches": 9
       }
     }
   },
@@ -805,20 +805,20 @@
         "neutral": "0-0"
       },
       "away": {
-        "overall": "6-1",
+        "overall": "7-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "1-0"
+        "neutral": "2-0"
       }
     },
     "rankings": {
       "away": {
-        "ap": 12,
-        "coaches": 11
+        "ap": 8,
+        "coaches": 9
       },
       "home": {
-        "ap": 23,
-        "coaches": 23
+        "ap": 21,
+        "coaches": 21
       }
     }
   },
@@ -842,16 +842,16 @@
         "neutral": "1-0"
       },
       "away": {
-        "overall": "6-1",
+        "overall": "7-1",
         "home": "3-1",
         "away": "2-0",
-        "neutral": "1-0"
+        "neutral": "2-0"
       }
     },
     "rankings": {
       "away": {
-        "ap": 12,
-        "coaches": 11
+        "ap": 8,
+        "coaches": 9
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated college football rankings for the date "2024-10-27," with Oregon and Miami leading.
	- New teams added to the rankings, including Washington State and Memphis.
  
- **Bug Fixes**
	- Adjusted game records and statistics for the 2024 season, ensuring accuracy in home and away team performance.
	- Updated rankings for various teams based on recent game outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->