### PR TITLE
Added polls from 2024-11-03

### DIFF
--- a/data/polls/2024.json
+++ b/data/polls/2024.json
@@ -1299,6 +1299,136 @@
           "previousRanking": 21
         }
       }
+    },
+    {
+      "date": "2024-11-03",
+      "teams": {
+        "Oregon": {
+          "record": "9-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Georgia": {
+          "record": "7-1",
+          "ranking": 2,
+          "previousRanking": 2
+        },
+        "Ohio State": {
+          "record": "7-1",
+          "ranking": 3,
+          "previousRanking": 4
+        },
+        "Miami": {
+          "record": "9-0",
+          "ranking": 4,
+          "previousRanking": 5
+        },
+        "Texas": {
+          "record": "7-1",
+          "ranking": 5,
+          "previousRanking": 6
+        },
+        "Penn State": {
+          "record": "7-1",
+          "ranking": 6,
+          "previousRanking": 3
+        },
+        "Tennessee": {
+          "record": "7-1",
+          "ranking": 7,
+          "previousRanking": 7
+        },
+        "Indiana": {
+          "record": "9-0",
+          "ranking": 8,
+          "previousRanking": 13
+        },
+        "BYU": {
+          "record": "8-0",
+          "ranking": 9,
+          "previousRanking": 9
+        },
+        "Notre Dame": {
+          "record": "7-1",
+          "ranking": 10,
+          "previousRanking": 8
+        },
+        "Alabama": {
+          "record": "6-2",
+          "ranking": 11,
+          "previousRanking": 14
+        },
+        "Boise State": {
+          "record": "7-1",
+          "ranking": 12,
+          "previousRanking": 15
+        },
+        "Southern Methodist": {
+          "record": "8-1",
+          "ranking": 13,
+          "previousRanking": 20
+        },
+        "LSU": {
+          "record": "6-2",
+          "ranking": 14,
+          "previousRanking": 16
+        },
+        "Texas A&M": {
+          "record": "7-2",
+          "ranking": 15,
+          "previousRanking": 10
+        },
+        "Ole Miss": {
+          "record": "7-2",
+          "ranking": 16,
+          "previousRanking": 19
+        },
+        "Iowa State": {
+          "record": "7-1",
+          "ranking": 17,
+          "previousRanking": 11
+        },
+        "Army": {
+          "record": "8-0",
+          "ranking": 18,
+          "previousRanking": 21
+        },
+        "Clemson": {
+          "record": "6-2",
+          "ranking": 19,
+          "previousRanking": 11
+        },
+        "Washington State": {
+          "record": "7-1",
+          "ranking": 20,
+          "previousRanking": 22
+        },
+        "Colorado": {
+          "record": "6-2",
+          "ranking": 21,
+          "previousRanking": 23
+        },
+        "Kansas State": {
+          "record": "7-2",
+          "ranking": 22,
+          "previousRanking": 17
+        },
+        "Pittsburgh": {
+          "record": "7-1",
+          "ranking": 23,
+          "previousRanking": 18
+        },
+        "Vanderbilt": {
+          "record": "6-3",
+          "ranking": 24,
+          "previousRanking": "NR"
+        },
+        "Louisville": {
+          "record": "6-3",
+          "ranking": 25,
+          "previousRanking": "NR"
+        }
+      }
     }
   ],
   "coaches": [
@@ -2597,6 +2727,136 @@
         },
         "Memphis": {
           "record": "7-1",
+          "ranking": 25,
+          "previousRanking": "NR"
+        }
+      }
+    },
+    {
+      "date": "2024-11-03",
+      "teams": {
+        "Oregon": {
+          "record": "9-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Georgia": {
+          "record": "7-1",
+          "ranking": 2,
+          "previousRanking": 2
+        },
+        "Ohio State": {
+          "record": "7-1",
+          "ranking": 3,
+          "previousRanking": 4
+        },
+        "Miami": {
+          "record": "9-0",
+          "ranking": 4,
+          "previousRanking": 5
+        },
+        "Texas": {
+          "record": "7-1",
+          "ranking": 5,
+          "previousRanking": 6
+        },
+        "Tennessee": {
+          "record": "7-1",
+          "ranking": 6,
+          "previousRanking": 7
+        },
+        "Penn State": {
+          "record": "7-1",
+          "ranking": 7,
+          "previousRanking": 3
+        },
+        "Notre Dame": {
+          "record": "7-1",
+          "ranking": 8,
+          "previousRanking": 9
+        },
+        "BYU": {
+          "record": "8-0",
+          "ranking": 9,
+          "previousRanking": 12
+        },
+        "Indiana": {
+          "record": "9-0",
+          "ranking": 10,
+          "previousRanking": 13
+        },
+        "Alabama": {
+          "record": "6-2",
+          "ranking": 11,
+          "previousRanking": 14
+        },
+        "Ole Miss": {
+          "record": "7-2",
+          "ranking": 12,
+          "previousRanking": 18
+        },
+        "LSU": {
+          "record": "6-2",
+          "ranking": 13,
+          "previousRanking": 16
+        },
+        "Boise State": {
+          "record": "7-1",
+          "ranking": 14,
+          "previousRanking": 19
+        },
+        "Southern Methodist": {
+          "record": "8-1",
+          "ranking": 15,
+          "previousRanking": 20
+        },
+        "Texas A&M": {
+          "record": "7-2",
+          "ranking": 16,
+          "previousRanking": 11
+        },
+        "Clemson": {
+          "record": "6-2",
+          "ranking": 17,
+          "previousRanking": 8
+        },
+        "Iowa State": {
+          "record": "7-1",
+          "ranking": 18,
+          "previousRanking": 10
+        },
+        "Army": {
+          "record": "8-0",
+          "ranking": 19,
+          "previousRanking": 21
+        },
+        "Washington State": {
+          "record": "7-1",
+          "ranking": 20,
+          "previousRanking": 22
+        },
+        "Kansas State": {
+          "record": "7-2",
+          "ranking": 21,
+          "previousRanking": 15
+        },
+        "Missouri": {
+          "record": "6-2",
+          "ranking": 22,
+          "previousRanking": 23
+        },
+        "Pittsburgh": {
+          "record": "7-1",
+          "ranking": 23,
+          "previousRanking": 17
+        },
+        "Colorado": {
+          "record": "6-2",
+          "ranking": 24,
+          "previousRanking": "NR"
+        },
+        "Vanderbilt": {
+          "record": "6-3",
           "ranking": 25,
           "previousRanking": "NR"
         }

--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -745,8 +745,8 @@
     },
     "rankings": {
       "home": {
-        "ap": 8,
-        "coaches": 9
+        "ap": 10,
+        "coaches": 8
       }
     }
   },
@@ -778,8 +778,8 @@
     },
     "rankings": {
       "home": {
-        "ap": 8,
-        "coaches": 9
+        "ap": 10,
+        "coaches": 8
       }
     }
   },
@@ -813,12 +813,12 @@
     },
     "rankings": {
       "away": {
-        "ap": 8,
-        "coaches": 9
+        "ap": 10,
+        "coaches": 8
       },
       "home": {
-        "ap": 21,
-        "coaches": 21
+        "ap": 18,
+        "coaches": 19
       }
     }
   },
@@ -850,8 +850,8 @@
     },
     "rankings": {
       "away": {
-        "ap": 8,
-        "coaches": 9
+        "ap": 10,
+        "coaches": 8
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new entries for team rankings and records for the date "2024-11-03" in both AP and coaches' sections.
	- Updated game schedule and statistics for the 2024 season, including new game entries and adjusted rankings.

- **Bug Fixes**
	- Corrected rankings for teams in several matchups, reflecting the latest performance metrics. 

- **Documentation**
	- Maintained consistent structure in JSON files for compatibility with existing systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->