### PR TITLE
Added Army 2024 results

### DIFF
--- a/data/polls/2024.json
+++ b/data/polls/2024.json
@@ -131,7 +131,7 @@
       }
     },
     {
-      "date": "2024-09-03",
+      "date": "2024-09-02",
       "teams": {
         "Georgia": {
           "record": "1-0",
@@ -261,7 +261,7 @@
       }
     },
     {
-      "date": "2024-09-08",
+      "date": "2024-09-07",
       "teams": {
         "Georgia": {
           "record": "2-0",
@@ -391,7 +391,7 @@
       }
     },
     {
-      "date": "2024-09-15",
+      "date": "2024-09-14",
       "teams": {
         "Texas": {
           "record": "3-0",
@@ -521,7 +521,7 @@
       }
     },
     {
-      "date": "2024-09-22",
+      "date": "2024-09-21",
       "teams": {
         "Texas": {
           "record": "4-0",
@@ -651,7 +651,7 @@
       }
     },
     {
-      "date": "2024-09-29",
+      "date": "2024-09-28",
       "teams": {
         "Alabama": {
           "record": "4-0",
@@ -781,7 +781,7 @@
       }
     },
     {
-      "date": "2024-10-06",
+      "date": "2024-10-05",
       "teams": {
         "Texas": {
           "record": "5-0",
@@ -911,7 +911,7 @@
       }
     },
     {
-      "date": "2024-10-13",
+      "date": "2024-10-12",
       "teams": {
         "Texas": {
           "record": "6-0",
@@ -1041,7 +1041,7 @@
       }
     },
     {
-      "date": "2024-10-20",
+      "date": "2024-10-19",
       "teams": {
         "Oregon": {
           "record": "7-0",
@@ -1171,7 +1171,7 @@
       }
     },
     {
-      "date": "2024-10-27",
+      "date": "2024-10-26",
       "teams": {
         "Oregon": {
           "record": "8-0",
@@ -1687,6 +1687,136 @@
           "record": "8-2",
           "ranking": 25,
           "previousRanking": 19
+        }
+      }
+    },
+    {
+      "date": "2024-11-24",
+      "teams": {
+        "Oregon": {
+          "record": "11-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Ohio State": {
+          "record": "10-1",
+          "ranking": 2,
+          "previousRanking": 2
+        },
+        "Texas": {
+          "record": "10-1",
+          "ranking": 3,
+          "previousRanking": 3
+        },
+        "Penn State": {
+          "record": "10-1",
+          "ranking": 4,
+          "previousRanking": 4
+        },
+        "Notre Dame": {
+          "record": "10-1",
+          "ranking": 5,
+          "previousRanking": 6
+        },
+        "Georgia": {
+          "record": "9-2",
+          "ranking": 6,
+          "previousRanking": 8
+        },
+        "Tennessee": {
+          "record": "9-2",
+          "ranking": 7,
+          "previousRanking": 10
+        },
+        "Miami": {
+          "record": "10-1",
+          "ranking": 8,
+          "previousRanking": 11
+        },
+        "Southern Methodist": {
+          "record": "10-1",
+          "ranking": 9,
+          "previousRanking": 13
+        },
+        "Indiana": {
+          "record": "10-1",
+          "ranking": 10,
+          "previousRanking": 5
+        },
+        "Boise State": {
+          "record": "10-1",
+          "ranking": 11,
+          "previousRanking": 12
+        },
+        "Clemson": {
+          "record": "9-2",
+          "ranking": 12,
+          "previousRanking": 17
+        },
+        "Alabama": {
+          "record": "8-3",
+          "ranking": 13,
+          "previousRanking": 7
+        },
+        "Arizona State": {
+          "record": "9-2",
+          "ranking": 14,
+          "previousRanking": 21
+        },
+        "Ole Miss": {
+          "record": "8-3",
+          "ranking": 15,
+          "previousRanking": 9
+        },
+        "South Carolina": {
+          "record": "8-3",
+          "ranking": 16,
+          "previousRanking": 19
+        },
+        "Iowa State": {
+          "record": "9-2",
+          "ranking": 17,
+          "previousRanking": 22
+        },
+        "Tulane": {
+          "record": "9-2",
+          "ranking": 18,
+          "previousRanking": 20
+        },
+        "BYU": {
+          "record": "9-2",
+          "ranking": 19,
+          "previousRanking": 14
+        },
+        "Texas A&M": {
+          "record": "8-3",
+          "ranking": 20,
+          "previousRanking": 15
+        },
+        "UNLV": {
+          "record": "9-2",
+          "ranking": 21,
+          "previousRanking": 23
+        },
+        "Illinois": {
+          "record": "8-3",
+          "ranking": 22,
+          "previousRanking": 24
+        },
+        "Colorado": {
+          "record": "8-3",
+          "ranking": 23,
+          "previousRanking": 16
+        },
+        "Missouri": {
+          "record": "8-3",
+          "ranking": 24,
+          "previousRanking": "NR"
+        },
+        "Army": {
+          "record": "9-1",
+          "ranking": 25,
+          "previousRanking": 18
         }
       }
     }
@@ -1823,7 +1953,7 @@
       }
     },
     {
-      "date": "2024-09-03",
+      "date": "2024-09-02",
       "teams": {
         "Georgia": {
           "record": "1-0",
@@ -1953,7 +2083,7 @@
       }
     },
     {
-      "date": "2024-09-08",
+      "date": "2024-09-07",
       "teams": {
         "Georgia": {
           "record": "2-0",
@@ -2083,7 +2213,7 @@
       }
     },
     {
-      "date": "2024-09-15",
+      "date": "2024-09-14",
       "teams": {
         "Georgia": {
           "record": "3-0",
@@ -2213,7 +2343,7 @@
       }
     },
     {
-      "date": "2024-09-22",
+      "date": "2024-09-21",
       "teams": {
         "Georgia": {
           "record": "3-0",
@@ -2343,7 +2473,7 @@
       }
     },
     {
-      "date": "2024-09-29",
+      "date": "2024-09-28",
       "teams": {
         "Texas": {
           "record": "5-0",
@@ -2473,7 +2603,7 @@
       }
     },
     {
-      "date": "2024-10-06",
+      "date": "2024-10-05",
       "teams": {
         "Texas": {
           "record": "5-0",
@@ -2603,7 +2733,7 @@
       }
     },
     {
-      "date": "2024-10-13",
+      "date": "2024-10-12",
       "teams": {
         "Texas": {
           "record": "6-0",
@@ -2733,7 +2863,7 @@
       }
     },
     {
-      "date": "2024-10-20",
+      "date": "2024-10-19",
       "teams": {
         "Oregon": {
           "record": "7-0",
@@ -2863,7 +2993,7 @@
       }
     },
     {
-      "date": "2024-10-27",
+      "date": "2024-10-26",
       "teams": {
         "Oregon": {
           "record": "8-0",
@@ -3379,6 +3509,136 @@
           "record": "7-3",
           "ranking": 25,
           "previousRanking": 19
+        }
+      }
+    },
+    {
+      "date": "2024-11-24",
+      "teams": {
+        "Oregon": {
+          "record": "11-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Ohio State": {
+          "record": "10-1",
+          "ranking": 2,
+          "previousRanking": 2
+        },
+        "Texas": {
+          "record": "10-1",
+          "ranking": 3,
+          "previousRanking": 3
+        },
+        "Penn State": {
+          "record": "10-1",
+          "ranking": 4,
+          "previousRanking": 4
+        },
+        "Notre Dame": {
+          "record": "10-1",
+          "ranking": 5,
+          "previousRanking": 6
+        },
+        "Georgia": {
+          "record": "9-2",
+          "ranking": 6,
+          "previousRanking": 8
+        },
+        "Miami": {
+          "record": "10-1",
+          "ranking": 7,
+          "previousRanking": 10
+        },
+        "Tennessee": {
+          "record": "9-2",
+          "ranking": 8,
+          "previousRanking": 11
+        },
+        "Southern Methodist": {
+          "record": "10-1",
+          "ranking": 9,
+          "previousRanking": 12
+        },
+        "Indiana": {
+          "record": "10-1",
+          "ranking": 10,
+          "previousRanking": 5
+        },
+        "Boise State": {
+          "record": "10-1",
+          "ranking": 11,
+          "previousRanking": 13
+        },
+        "Clemson": {
+          "record": "9-2",
+          "ranking": 12,
+          "previousRanking": 16
+        },
+        "Alabama": {
+          "record": "8-3",
+          "ranking": 13,
+          "previousRanking": 7
+        },
+        "South Carolina": {
+          "record": "8-3",
+          "ranking": 14,
+          "previousRanking": 19
+        },
+        "Arizona State": {
+          "record": "9-2",
+          "ranking": 15,
+          "previousRanking": 22
+        },
+        "Ole Miss": {
+          "record": "8-3",
+          "ranking": 16,
+          "previousRanking": 9
+        },
+        "Iowa State": {
+          "record": "9-2",
+          "ranking": 17,
+          "previousRanking": 21
+        },
+        "Tulane": {
+          "record": "9-2",
+          "ranking": 18,
+          "previousRanking": 20
+        },
+        "Texas A&M": {
+          "record": "8-3",
+          "ranking": 19,
+          "previousRanking": 14
+        },
+        "BYU": {
+          "record": "9-2",
+          "ranking": 20,
+          "previousRanking": 15
+        },
+        "UNLV": {
+          "record": "9-2",
+          "ranking": 21,
+          "previousRanking": 23
+        },
+        "Army": {
+          "record": "9-1",
+          "ranking": 22,
+          "previousRanking": 17
+        },
+        "Memphis": {
+          "record": "9-2",
+          "ranking": 23,
+          "previousRanking": 24
+        },
+        "Missouri": {
+          "record": "8-3",
+          "ranking": 24,
+          "previousRanking": "NR"
+        },
+        "Illinois": {
+          "record": "8-3",
+          "ranking": 25,
+          "previousRanking": "NR"
         }
       }
     }

--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -174,8 +174,11 @@
     "result": "L",
     "rankings": {
       "home": {
-        "ap": 5,
-        "coaches": 7
+        "ap": 18,
+        "coaches": 19
+      },
+      "away": {
+        "ap": 25
       }
     }
   },
@@ -262,8 +265,8 @@
     "result": "W",
     "rankings": {
       "away": {
-        "ap": 18,
-        "coaches": 19
+        "ap": 17,
+        "coaches": 18
       }
     }
   },
@@ -350,8 +353,8 @@
     "result": "W",
     "rankings": {
       "home": {
-        "ap": 17,
-        "coaches": 18
+        "ap": 16,
+        "coaches": 14
       }
     }
   },
@@ -438,12 +441,12 @@
     "result": "W",
     "rankings": {
       "home": {
-        "ap": 16,
-        "coaches": 14
+        "ap": 14,
+        "coaches": 13
       },
       "away": {
-        "ap": 15,
-        "coaches": 17
+        "ap": 22,
+        "coaches": 22
       }
     }
   },
@@ -530,8 +533,8 @@
     "result": "W",
     "rankings": {
       "home": {
-        "ap": 11,
-        "coaches": 12
+        "ap": 12,
+        "coaches": 11
       }
     }
   },
@@ -708,12 +711,8 @@
     "result": "W",
     "rankings": {
       "away": {
-        "ap": 12,
-        "coaches": 11
-      },
-      "home": {
-        "ap": 24,
-        "coaches": 24
+        "ap": 8,
+        "coaches": 9
       }
     }
   },
@@ -894,7 +893,7 @@
     }
   },
   {
-    "isHomeGame": false,
+    "isHomeGame": true,
     "isShamrockSeries": true,
     "isNeutralSiteGame": true,
     "coverage": "NBC",
@@ -907,20 +906,75 @@
     },
     "opponentId": "ARMY",
     "espnGameId": 401640959,
+    "highlightsYouTubeVideoId": "W8TAmjiZR-0",
     "records": {
       "home": {
-        "overall": "9-0",
+        "overall": "9-1",
         "home": "5-0",
         "away": "4-0",
-        "neutral": "0-0"
+        "neutral": "0-1"
       },
       "away": {
-        "overall": "9-1",
+        "overall": "10-1",
         "home": "5-1",
         "away": "2-0",
-        "neutral": "2-0"
+        "neutral": "3-0"
       }
     },
+    "headCoach": "Marcus Freeman",
+    "stats": {
+      "away": {
+        "firstDowns": 15,
+        "thirdDownAttempts": 17,
+        "thirdDownConversions": 6,
+        "fourthDownAttempts": 4,
+        "fourthDownConversions": 1,
+        "totalYards": 233,
+        "passYards": 26,
+        "passCompletions": 4,
+        "passAttempts": 9,
+        "yardsPerPass": 2.9,
+        "interceptionsThrown": 0,
+        "rushYards": 207,
+        "rushAttempts": 58,
+        "yardsPerRush": 3.6,
+        "penalties": 2,
+        "penaltyYards": 26,
+        "possession": "39:49",
+        "fumblesLost": 1,
+        "fumbles": 1
+      },
+      "home": {
+        "firstDowns": 19,
+        "thirdDownAttempts": 5,
+        "thirdDownConversions": 3,
+        "fourthDownAttempts": 1,
+        "fourthDownConversions": 0,
+        "totalYards": 464,
+        "passYards": 189,
+        "passCompletions": 14,
+        "passAttempts": 18,
+        "yardsPerPass": 10.5,
+        "interceptionsThrown": 0,
+        "rushYards": 275,
+        "rushAttempts": 28,
+        "yardsPerRush": 9.8,
+        "penalties": 5,
+        "penaltyYards": 44,
+        "possession": "20:11",
+        "fumblesLost": 0,
+        "fumbles": 1
+      }
+    },
+    "score": {
+      "home": 49,
+      "away": 14
+    },
+    "linescore": {
+      "away": [0, 7, 0, 7],
+      "home": [14, 14, 14, 7]
+    },
+    "result": "L",
     "rankings": {
       "away": {
         "ap": 6,
@@ -934,8 +988,8 @@
   },
   {
     "isHomeGame": false,
-    "date": "11/30/2024",
-    "coverage": "TBD",
+    "fullDate": "Sat Nov 30 2024 15:30:00 GMT-0500",
+    "coverage": "CBS",
     "location": {
       "city": "Los Angeles",
       "state": "CA",
@@ -946,22 +1000,22 @@
     "espnGameId": 401628571,
     "records": {
       "home": {
-        "overall": "5-5",
+        "overall": "6-5",
         "home": "4-1",
-        "away": "0-4",
+        "away": "1-4",
         "neutral": "1-0"
       },
       "away": {
-        "overall": "9-1",
+        "overall": "10-1",
         "home": "5-1",
         "away": "2-0",
-        "neutral": "2-0"
+        "neutral": "3-0"
       }
     },
     "rankings": {
       "away": {
-        "ap": 6,
-        "coaches": 6
+        "ap": 5,
+        "coaches": 5
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated college football rankings and records for the 2024 season.
	- Added new game entry against Army on November 23, 2024, with detailed statistics.
	- Updated game against USC on November 30, 2024, with specific date and CBS coverage.

- **Bug Fixes**
	- Adjusted dates for several games to reflect accurate scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->