### PR TITLE
Added 2024 Indiana game and polls from 2024-12-08

### DIFF
--- a/data/polls/2024.json
+++ b/data/polls/2024.json
@@ -1949,6 +1949,136 @@
           "previousRanking": "NR"
         }
       }
+    },
+    {
+      "date": "2024-12-08",
+      "teams": {
+        "Oregon": {
+          "record": "13-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Georgia": {
+          "record": "11-2",
+          "ranking": 2,
+          "previousRanking": 5
+        },
+        "Notre Dame": {
+          "record": "11-1",
+          "ranking": 3,
+          "previousRanking": 4
+        },
+        "Texas": {
+          "record": "11-2",
+          "ranking": 4,
+          "previousRanking": 2
+        },
+        "Penn State": {
+          "record": "11-2",
+          "ranking": 5,
+          "previousRanking": 3
+        },
+        "Ohio State": {
+          "record": "10-2",
+          "ranking": 6,
+          "previousRanking": 7
+        },
+        "Tennessee": {
+          "record": "10-2",
+          "ranking": 7,
+          "previousRanking": 6
+        },
+        "Boise State": {
+          "record": "12-1",
+          "ranking": 8,
+          "previousRanking": 10
+        },
+        "Indiana": {
+          "record": "11-1",
+          "ranking": 9,
+          "previousRanking": 9
+        },
+        "Arizona State": {
+          "record": "11-2",
+          "ranking": 10,
+          "previousRanking": 12
+        },
+        "Alabama": {
+          "record": "9-3",
+          "ranking": 11,
+          "previousRanking": 11
+        },
+        "Southern Methodist": {
+          "record": "11-2",
+          "ranking": 12,
+          "previousRanking": 8
+        },
+        "Clemson": {
+          "record": "10-3",
+          "ranking": 13,
+          "previousRanking": 18
+        },
+        "South Carolina": {
+          "record": "9-3",
+          "ranking": 14,
+          "previousRanking": 13
+        },
+        "Miami": {
+          "record": "10-2",
+          "ranking": 15,
+          "previousRanking": 14
+        },
+        "Ole Miss": {
+          "record": "9-3",
+          "ranking": 16,
+          "previousRanking": 15
+        },
+        "BYU": {
+          "record": "10-2",
+          "ranking": 17,
+          "previousRanking": 17
+        },
+        "Iowa State": {
+          "record": "10-3",
+          "ranking": 18,
+          "previousRanking": 16
+        },
+        "Army": {
+          "record": "11-1",
+          "ranking": 19,
+          "previousRanking": 24
+        },
+        "Colorado": {
+          "record": "9-3",
+          "ranking": 20,
+          "previousRanking": 20
+        },
+        "Illinois": {
+          "record": "9-3",
+          "ranking": 21,
+          "previousRanking": 21
+        },
+        "Syracuse": {
+          "record": "9-3",
+          "ranking": 22,
+          "previousRanking": 23
+        },
+        "Missouri": {
+          "record": "9-3",
+          "ranking": 23,
+          "previousRanking": 22
+        },
+        "UNLV": {
+          "record": "10-3",
+          "ranking": 24,
+          "previousRanking": 19
+        },
+        "Memphis": {
+          "record": "10-2",
+          "ranking": 25,
+          "previousRanking": 25
+        }
+      }
     }
   ],
   "coaches": [
@@ -3899,6 +4029,136 @@
           "record": "9-3",
           "ranking": 25,
           "previousRanking": "NR"
+        }
+      }
+    },
+    {
+      "date": "2024-12-08",
+      "teams": {
+        "Oregon": {
+          "record": "13-0",
+          "ranking": 1,
+          "previousRanking": 1
+        },
+        "Georgia": {
+          "record": "11-2",
+          "ranking": 2,
+          "previousRanking": 5
+        },
+        "Notre Dame": {
+          "record": "11-1",
+          "ranking": 3,
+          "previousRanking": 4
+        },
+        "Texas": {
+          "record": "11-2",
+          "ranking": 4,
+          "previousRanking": 2
+        },
+        "Penn State": {
+          "record": "11-2",
+          "ranking": 5,
+          "previousRanking": 3
+        },
+        "Tennessee": {
+          "record": "10-2",
+          "ranking": 6,
+          "previousRanking": 6
+        },
+        "Ohio State": {
+          "record": "10-2",
+          "ranking": 7,
+          "previousRanking": 8
+        },
+        "Boise State": {
+          "record": "12-1",
+          "ranking": 8,
+          "previousRanking": 10
+        },
+        "Indiana": {
+          "record": "11-1",
+          "ranking": 9,
+          "previousRanking": 9
+        },
+        "Arizona State": {
+          "record": "11-2",
+          "ranking": 10,
+          "previousRanking": 13
+        },
+        "Alabama": {
+          "record": "9-3",
+          "ranking": 11,
+          "previousRanking": 11
+        },
+        "Southern Methodist": {
+          "record": "11-2",
+          "ranking": 12,
+          "previousRanking": 7
+        },
+        "Clemson": {
+          "record": "10-3",
+          "ranking": 13,
+          "previousRanking": 17
+        },
+        "South Carolina": {
+          "record": "9-3",
+          "ranking": 14,
+          "previousRanking": 12
+        },
+        "Ole Miss": {
+          "record": "9-3",
+          "ranking": 15,
+          "previousRanking": 15
+        },
+        "Miami": {
+          "record": "10-2",
+          "ranking": 16,
+          "previousRanking": 14
+        },
+        "BYU": {
+          "record": "10-2",
+          "ranking": 17,
+          "previousRanking": 18
+        },
+        "Army": {
+          "record": "11-1",
+          "ranking": 18,
+          "previousRanking": 23
+        },
+        "Iowa State": {
+          "record": "10-3",
+          "ranking": 19,
+          "previousRanking": 16
+        },
+        "Missouri": {
+          "record": "9-3",
+          "ranking": 20,
+          "previousRanking": 20
+        },
+        "Illinois": {
+          "record": "9-3",
+          "ranking": 21,
+          "previousRanking": 21
+        },
+        "Colorado": {
+          "record": "9-3",
+          "ranking": 22,
+          "previousRanking": 22
+        },
+        "Memphis": {
+          "record": "10-2",
+          "ranking": 23,
+          "previousRanking": 24
+        },
+        "UNLV": {
+          "record": "10-3",
+          "ranking": 24,
+          "previousRanking": 19
+        },
+        "Syracuse": {
+          "record": "9-3",
+          "ranking": 25,
+          "previousRanking": 25
         }
       }
     }

--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -951,15 +951,15 @@
         "thirdDownConversions": 3,
         "fourthDownAttempts": 1,
         "fourthDownConversions": 0,
-        "totalYards": 462,
+        "totalYards": 464,
         "passYards": 189,
         "passCompletions": 14,
         "passAttempts": 18,
         "yardsPerPass": 10.5,
         "interceptionsThrown": 0,
-        "rushYards": 273,
-        "rushAttempts": 29,
-        "yardsPerRush": 9.4,
+        "rushYards": 275,
+        "rushAttempts": 28,
+        "yardsPerRush": 9.8,
         "penalties": 5,
         "penaltyYards": 44,
         "possession": "20:11",
@@ -1022,15 +1022,15 @@
         "thirdDownConversions": 3,
         "fourthDownAttempts": 3,
         "fourthDownConversions": 3,
-        "totalYards": 438,
+        "totalYards": 436,
         "passYards": 178,
         "passCompletions": 18,
         "passAttempts": 23,
         "yardsPerPass": 7.7,
         "interceptionsThrown": 1,
-        "rushYards": 260,
-        "rushAttempts": 37,
-        "yardsPerRush": 7,
+        "rushYards": 258,
+        "rushAttempts": 38,
+        "yardsPerRush": 6.8,
         "penalties": 3,
         "penaltyYards": 44,
         "possession": "29:45",
@@ -1072,6 +1072,46 @@
       "away": {
         "ap": 5,
         "coaches": 5
+      }
+    }
+  },
+  {
+    "isHomeGame": true,
+    "isBowlGame": true,
+    "isNeutralSiteGame": true,
+    "espnGameId": 401677179,
+    "nickname": "College Football Playoff First Round Game",
+    "fullDate": "Sat Dec 20 2024 18:00:00 GMT-0700",
+    "coverage": "ABC / ESPN",
+    "location": {
+      "city": "Notre Dame",
+      "state": "IN",
+      "stadium": "Notre Dame Stadium",
+      "coordinates": [41.698399, -86.233917]
+    },
+    "opponentId": "IND",
+    "records": {
+      "home": {
+        "overall": "11-1",
+        "home": "5-1",
+        "away": "3-0",
+        "neutral": "3-0"
+      },
+      "away": {
+        "overall": "11-1",
+        "home": "8-0",
+        "away": "3-1",
+        "neutral": "0-0"
+      }
+    },
+    "rankings": {
+      "home": {
+        "ap": 3,
+        "coaches": 3
+      },
+      "away": {
+        "ap": 9,
+        "coaches": 9
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new game entry for a bowl game scheduled on December 20, 2024, at Notre Dame Stadium.
	- Updated standings for teams as of December 8, 2024, reflecting current records and rankings.

- **Bug Fixes**
	- Minor adjustments made to statistics for existing game entries against "ARMY" and "USC".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->