### PR TITLE
Updated game time for ND vs UGA quarterfinal

### DIFF
--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -1175,7 +1175,7 @@
     "isNeutralSiteGame": true,
     "espnGameId": 401677184,
     "nickname": "College Football Playoff Quarterfinal at the Allstate Sugar Bowl",
-    "fullDate": "Wed Jan 01 2025 18:45:00 GMT-0700",
+    "fullDate": "Wed Jan 02 2025 14:00:00 GMT-0700",
     "coverage": "ESPN",
     "location": {
       "city": "New Orleans",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Schedule Update**
	- Updated the date and time for the College Football Playoff Quarterfinal game against UGA from January 1st to January 2nd, 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->