### PR TITLE
Correct Orange Bowl stadium names

### DIFF
--- a/website/src/resources/schedules/1960.json
+++ b/website/src/resources/schedules/1960.json
@@ -202,7 +202,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1965.json
+++ b/website/src/resources/schedules/1965.json
@@ -272,7 +272,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1967.json
+++ b/website/src/resources/schedules/1967.json
@@ -262,7 +262,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1971.json
+++ b/website/src/resources/schedules/1971.json
@@ -92,7 +92,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1972.json
+++ b/website/src/resources/schedules/1972.json
@@ -319,7 +319,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "NEB",

--- a/website/src/resources/schedules/1973.json
+++ b/website/src/resources/schedules/1973.json
@@ -294,7 +294,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1974.json
+++ b/website/src/resources/schedules/1974.json
@@ -361,7 +361,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "BAMA",

--- a/website/src/resources/schedules/1975.json
+++ b/website/src/resources/schedules/1975.json
@@ -321,7 +321,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1977.json
+++ b/website/src/resources/schedules/1977.json
@@ -327,7 +327,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1981.json
+++ b/website/src/resources/schedules/1981.json
@@ -300,7 +300,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1983.json
+++ b/website/src/resources/schedules/1983.json
@@ -68,7 +68,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1985.json
+++ b/website/src/resources/schedules/1985.json
@@ -300,7 +300,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1987.json
+++ b/website/src/resources/schedules/1987.json
@@ -331,7 +331,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",

--- a/website/src/resources/schedules/1989.json
+++ b/website/src/resources/schedules/1989.json
@@ -364,7 +364,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "MIAMI",
@@ -401,7 +401,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "COL",

--- a/website/src/resources/schedules/1990.json
+++ b/website/src/resources/schedules/1990.json
@@ -374,7 +374,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "COL",

--- a/website/src/resources/schedules/1995.json
+++ b/website/src/resources/schedules/1995.json
@@ -372,7 +372,7 @@
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Miami Orange Bowl",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "FSU",

--- a/website/src/resources/schedules/2024.json
+++ b/website/src/resources/schedules/2024.json
@@ -1271,10 +1271,11 @@
     "espnGameId": 401677189,
     "nickname": "College Football Playoff Semifinal at the Orange Bowl",
     "fullDate": "Thu Jan 09 2025 17:30:00 GMT-0700",
+    "coverage": "ESPN",
     "location": {
       "city": "Miami",
       "state": "FL",
-      "stadium": "Orange Bowl",
+      "stadium": "Hard Rock Stadium",
       "coordinates": [25.777936, -80.220957]
     },
     "opponentId": "PSU"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Data Updates**
  - Updated stadium names from "Orange Bowl" to "Miami Orange Bowl" in historical game schedules from 1960 to 1995
  - Updated stadium name to "Hard Rock Stadium" for a 2024 game schedule
  - Added game coverage information for a 2024 game
  - Added bowl game and neutral site game indicators for some entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->