### PR TITLE
Updated future schedules, mostly CLEM

### DIFF
--- a/data/polls/2024.json
+++ b/data/polls/2024.json
@@ -2134,7 +2134,7 @@
           "previousRanking": 9
         },
         "Ole Miss": {
-          "record": "11-3",
+          "record": "10-3",
           "ranking": 11,
           "previousRanking": 16
         },

--- a/website/src/resources/schedules/2026.json
+++ b/website/src/resources/schedules/2026.json
@@ -2,7 +2,8 @@
   {
     "isHomeGame": false,
     "isShamrockSeries": true,
-    "date": "09/05/2026",
+    "date": "09/06/2026",
+    "coverage": "NBC",
     "location": {
       "city": "Green Bay",
       "state": "WI",

--- a/website/src/resources/schedules/2029.json
+++ b/website/src/resources/schedules/2029.json
@@ -97,5 +97,16 @@
       "coordinates": [41.698399, -86.233917]
     },
     "opponentId": "NAVY"
+  },
+  {
+    "isHomeGame": false,
+    "date": "TBD",
+    "location": {
+      "city": "Clemson",
+      "state": "SC",
+      "stadium": "Clemson Memorial Stadium",
+      "coordinates": [34.678643, -82.84322]
+    },
+    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2030.json
+++ b/website/src/resources/schedules/2030.json
@@ -86,5 +86,16 @@
       "coordinates": [38.985, -76.507]
     },
     "opponentId": "NAVY"
+  },
+  {
+    "isHomeGame": true,
+    "date": "TBD",
+    "location": {
+      "city": "Notre Dame",
+      "state": "IN",
+      "stadium": "Notre Dame Stadium",
+      "coordinates": [41.698399, -86.233917]
+    },
+    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2032.json
+++ b/website/src/resources/schedules/2032.json
@@ -75,5 +75,16 @@
       "coordinates": [38.985, -76.507]
     },
     "opponentId": "NAVY"
+  },
+  {
+    "isHomeGame": true,
+    "date": "TBD",
+    "location": {
+      "city": "Notre Dame",
+      "state": "IN",
+      "stadium": "Notre Dame Stadium",
+      "coordinates": [41.698399, -86.233917]
+    },
+    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2033.json
+++ b/website/src/resources/schedules/2033.json
@@ -64,5 +64,16 @@
       "coordinates": [38.206123, -85.759065]
     },
     "opponentId": "LOU"
+  },
+  {
+    "isHomeGame": false,
+    "date": "TBD",
+    "location": {
+      "city": "Clemson",
+      "state": "SC",
+      "stadium": "Clemson Memorial Stadium",
+      "coordinates": [34.678643, -82.84322]
+    },
+    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2035.json
+++ b/website/src/resources/schedules/2035.json
@@ -53,5 +53,16 @@
       "coordinates": [38.206123, -85.759065]
     },
     "opponentId": "LOU"
+  },
+  {
+    "isHomeGame": false,
+    "date": "TBD",
+    "location": {
+      "city": "Clemson",
+      "state": "SC",
+      "stadium": "Clemson Memorial Stadium",
+      "coordinates": [34.678643, -82.84322]
+    },
+    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2036.json
+++ b/website/src/resources/schedules/2036.json
@@ -53,5 +53,16 @@
       "coordinates": [41.698399, -86.233917]
     },
     "opponentId": "UNC"
+  },
+  {
+    "isHomeGame": true,
+    "date": "TBD",
+    "location": {
+      "city": "Notre Dame",
+      "state": "IN",
+      "stadium": "Notre Dame Stadium",
+      "coordinates": [41.698399, -86.233917]
+    },
+    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2038.json
+++ b/website/src/resources/schedules/2038.json
@@ -1,0 +1,13 @@
+[
+  {
+    "isHomeGame": true,
+    "date": "TBD",
+    "location": {
+      "city": "Notre Dame",
+      "state": "IN",
+      "stadium": "Notre Dame Stadium",
+      "coordinates": [41.698399, -86.233917]
+    },
+    "opponentId": "CLEM"
+  }
+]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added future football games between Notre Dame and Clemson to schedules for 2029, 2030, 2032, 2033, 2035, 2036, and 2038, including details for home and away matchups.
	- Introduced a new 2038 schedule file with an initial home game entry.

- **Updates**
	- Updated the date and added TV coverage information for the 2026 Shamrock Series game.
	- Corrected the 2025 record for Ole Miss in the AP poll.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->