### PR TITLE
Refresh future season schedules + sitemap

### DIFF
--- a/scripts/lib/constants.ts
+++ b/scripts/lib/constants.ts
@@ -1,6 +1,6 @@
 import range from 'lodash/range';
 
-export const LATEST_SEASON = 2037;
+export const LATEST_SEASON = 2038;
 export const CURRENT_SEASON = 2026;
 
 export const ALL_SEASONS = [1887, 1888, 1889, ...range(1892, LATEST_SEASON + 1)];

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://notreda.me/</loc></url>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url><loc>https://notreda.me/</loc></url>
   <url><loc>https://notreda.me/explorables/</loc></url>
   <url><loc>https://notreda.me/explorables/s1e1-down-to-the-wire/</loc></url>
   <url><loc>https://notreda.me/explorables/s1e2-chasing-perfection</loc></url>
@@ -1432,6 +1432,7 @@
   <url><loc>https://notreda.me/2019/10/</loc></url>
   <url><loc>https://notreda.me/2019/11/</loc></url>
   <url><loc>https://notreda.me/2019/12/</loc></url>
+  <url><loc>https://notreda.me/2019/13/</loc></url>
   <url><loc>https://notreda.me/2020/</loc></url>
   <url><loc>https://notreda.me/2020/1/</loc></url>
   <url><loc>https://notreda.me/2020/2/</loc></url>
@@ -1458,6 +1459,7 @@
   <url><loc>https://notreda.me/2021/10/</loc></url>
   <url><loc>https://notreda.me/2021/11/</loc></url>
   <url><loc>https://notreda.me/2021/12/</loc></url>
+  <url><loc>https://notreda.me/2021/13/</loc></url>
   <url><loc>https://notreda.me/2022/</loc></url>
   <url><loc>https://notreda.me/2022/1/</loc></url>
   <url><loc>https://notreda.me/2022/2/</loc></url>
@@ -1468,6 +1470,10 @@
   <url><loc>https://notreda.me/2022/7/</loc></url>
   <url><loc>https://notreda.me/2022/8/</loc></url>
   <url><loc>https://notreda.me/2022/9/</loc></url>
+  <url><loc>https://notreda.me/2022/10/</loc></url>
+  <url><loc>https://notreda.me/2022/11/</loc></url>
+  <url><loc>https://notreda.me/2022/12/</loc></url>
+  <url><loc>https://notreda.me/2022/13/</loc></url>
   <url><loc>https://notreda.me/2023/</loc></url>
   <url><loc>https://notreda.me/2023/1/</loc></url>
   <url><loc>https://notreda.me/2023/2/</loc></url>
@@ -1479,6 +1485,9 @@
   <url><loc>https://notreda.me/2023/8/</loc></url>
   <url><loc>https://notreda.me/2023/9/</loc></url>
   <url><loc>https://notreda.me/2023/10/</loc></url>
+  <url><loc>https://notreda.me/2023/11/</loc></url>
+  <url><loc>https://notreda.me/2023/12/</loc></url>
+  <url><loc>https://notreda.me/2023/13/</loc></url>
   <url><loc>https://notreda.me/2024/</loc></url>
   <url><loc>https://notreda.me/2024/1/</loc></url>
   <url><loc>https://notreda.me/2024/2/</loc></url>
@@ -1490,6 +1499,12 @@
   <url><loc>https://notreda.me/2024/8/</loc></url>
   <url><loc>https://notreda.me/2024/9/</loc></url>
   <url><loc>https://notreda.me/2024/10/</loc></url>
+  <url><loc>https://notreda.me/2024/11/</loc></url>
+  <url><loc>https://notreda.me/2024/12/</loc></url>
+  <url><loc>https://notreda.me/2024/13/</loc></url>
+  <url><loc>https://notreda.me/2024/14/</loc></url>
+  <url><loc>https://notreda.me/2024/15/</loc></url>
+  <url><loc>https://notreda.me/2024/16/</loc></url>
   <url><loc>https://notreda.me/2025/</loc></url>
   <url><loc>https://notreda.me/2025/1/</loc></url>
   <url><loc>https://notreda.me/2025/2/</loc></url>
@@ -1501,6 +1516,8 @@
   <url><loc>https://notreda.me/2025/8/</loc></url>
   <url><loc>https://notreda.me/2025/9/</loc></url>
   <url><loc>https://notreda.me/2025/10/</loc></url>
+  <url><loc>https://notreda.me/2025/11/</loc></url>
+  <url><loc>https://notreda.me/2025/12/</loc></url>
   <url><loc>https://notreda.me/2026/</loc></url>
   <url><loc>https://notreda.me/2026/1/</loc></url>
   <url><loc>https://notreda.me/2026/2/</loc></url>
@@ -1511,6 +1528,9 @@
   <url><loc>https://notreda.me/2026/7/</loc></url>
   <url><loc>https://notreda.me/2026/8/</loc></url>
   <url><loc>https://notreda.me/2026/9/</loc></url>
+  <url><loc>https://notreda.me/2026/10/</loc></url>
+  <url><loc>https://notreda.me/2026/11/</loc></url>
+  <url><loc>https://notreda.me/2026/12/</loc></url>
   <url><loc>https://notreda.me/2027/</loc></url>
   <url><loc>https://notreda.me/2027/1/</loc></url>
   <url><loc>https://notreda.me/2027/2/</loc></url>
@@ -1519,6 +1539,11 @@
   <url><loc>https://notreda.me/2027/5/</loc></url>
   <url><loc>https://notreda.me/2027/6/</loc></url>
   <url><loc>https://notreda.me/2027/7/</loc></url>
+  <url><loc>https://notreda.me/2027/8/</loc></url>
+  <url><loc>https://notreda.me/2027/9/</loc></url>
+  <url><loc>https://notreda.me/2027/10/</loc></url>
+  <url><loc>https://notreda.me/2027/11/</loc></url>
+  <url><loc>https://notreda.me/2027/12/</loc></url>
   <url><loc>https://notreda.me/2028/</loc></url>
   <url><loc>https://notreda.me/2028/1/</loc></url>
   <url><loc>https://notreda.me/2028/2/</loc></url>
@@ -1528,6 +1553,9 @@
   <url><loc>https://notreda.me/2028/6/</loc></url>
   <url><loc>https://notreda.me/2028/7/</loc></url>
   <url><loc>https://notreda.me/2028/8/</loc></url>
+  <url><loc>https://notreda.me/2028/9/</loc></url>
+  <url><loc>https://notreda.me/2028/10/</loc></url>
+  <url><loc>https://notreda.me/2028/11/</loc></url>
   <url><loc>https://notreda.me/2029/</loc></url>
   <url><loc>https://notreda.me/2029/1/</loc></url>
   <url><loc>https://notreda.me/2029/2/</loc></url>
@@ -1535,24 +1563,40 @@
   <url><loc>https://notreda.me/2029/4/</loc></url>
   <url><loc>https://notreda.me/2029/5/</loc></url>
   <url><loc>https://notreda.me/2029/6/</loc></url>
+  <url><loc>https://notreda.me/2029/7/</loc></url>
+  <url><loc>https://notreda.me/2029/8/</loc></url>
+  <url><loc>https://notreda.me/2029/9/</loc></url>
+  <url><loc>https://notreda.me/2029/10/</loc></url>
   <url><loc>https://notreda.me/2030/</loc></url>
   <url><loc>https://notreda.me/2030/1/</loc></url>
   <url><loc>https://notreda.me/2030/2/</loc></url>
   <url><loc>https://notreda.me/2030/3/</loc></url>
   <url><loc>https://notreda.me/2030/4/</loc></url>
   <url><loc>https://notreda.me/2030/5/</loc></url>
+  <url><loc>https://notreda.me/2030/6/</loc></url>
+  <url><loc>https://notreda.me/2030/7/</loc></url>
+  <url><loc>https://notreda.me/2030/8/</loc></url>
+  <url><loc>https://notreda.me/2030/9/</loc></url>
   <url><loc>https://notreda.me/2031/</loc></url>
   <url><loc>https://notreda.me/2031/1/</loc></url>
   <url><loc>https://notreda.me/2031/2/</loc></url>
   <url><loc>https://notreda.me/2031/3/</loc></url>
   <url><loc>https://notreda.me/2031/4/</loc></url>
   <url><loc>https://notreda.me/2031/5/</loc></url>
+  <url><loc>https://notreda.me/2031/6/</loc></url>
+  <url><loc>https://notreda.me/2031/7/</loc></url>
+  <url><loc>https://notreda.me/2031/8/</loc></url>
+  <url><loc>https://notreda.me/2031/9/</loc></url>
+  <url><loc>https://notreda.me/2031/10/</loc></url>
   <url><loc>https://notreda.me/2032/</loc></url>
   <url><loc>https://notreda.me/2032/1/</loc></url>
   <url><loc>https://notreda.me/2032/2/</loc></url>
   <url><loc>https://notreda.me/2032/3/</loc></url>
   <url><loc>https://notreda.me/2032/4/</loc></url>
   <url><loc>https://notreda.me/2032/5/</loc></url>
+  <url><loc>https://notreda.me/2032/6/</loc></url>
+  <url><loc>https://notreda.me/2032/7/</loc></url>
+  <url><loc>https://notreda.me/2032/8/</loc></url>
   <url><loc>https://notreda.me/2033/</loc></url>
   <url><loc>https://notreda.me/2033/1/</loc></url>
   <url><loc>https://notreda.me/2033/2/</loc></url>
@@ -1560,6 +1604,7 @@
   <url><loc>https://notreda.me/2033/4/</loc></url>
   <url><loc>https://notreda.me/2033/5/</loc></url>
   <url><loc>https://notreda.me/2033/6/</loc></url>
+  <url><loc>https://notreda.me/2033/7/</loc></url>
   <url><loc>https://notreda.me/2034/</loc></url>
   <url><loc>https://notreda.me/2034/1/</loc></url>
   <url><loc>https://notreda.me/2034/2/</loc></url>
@@ -1573,16 +1618,21 @@
   <url><loc>https://notreda.me/2035/3/</loc></url>
   <url><loc>https://notreda.me/2035/4/</loc></url>
   <url><loc>https://notreda.me/2035/5/</loc></url>
+  <url><loc>https://notreda.me/2035/6/</loc></url>
   <url><loc>https://notreda.me/2036/</loc></url>
   <url><loc>https://notreda.me/2036/1/</loc></url>
   <url><loc>https://notreda.me/2036/2/</loc></url>
   <url><loc>https://notreda.me/2036/3/</loc></url>
   <url><loc>https://notreda.me/2036/4/</loc></url>
   <url><loc>https://notreda.me/2036/5/</loc></url>
+  <url><loc>https://notreda.me/2036/6/</loc></url>
   <url><loc>https://notreda.me/2037/</loc></url>
   <url><loc>https://notreda.me/2037/1/</loc></url>
   <url><loc>https://notreda.me/2037/2/</loc></url>
   <url><loc>https://notreda.me/2037/3/</loc></url>
   <url><loc>https://notreda.me/2037/4/</loc></url>
   <url><loc>https://notreda.me/2037/5/</loc></url>
-</urlset>
+  <url><loc>https://notreda.me/2038/</loc></url>
+  <url><loc>https://notreda.me/2038/1/</loc></url>
+  </urlset>
+  

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -2,7 +2,7 @@ import range from 'lodash/range';
 
 import theme from '../resources/theme.json';
 
-export const LATEST_SEASON = 2037;
+export const LATEST_SEASON = 2038;
 export const CURRENT_SEASON = 2026;
 export const DEFAULT_TEAM_COLOR = theme.colors.red;
 

--- a/website/src/models/teams.models.ts
+++ b/website/src/models/teams.models.ts
@@ -100,6 +100,7 @@ export enum TeamId {
   IOWA = 'IOWA',
   ISU = 'ISU',
   KAL = 'KAL',
+  KENT = 'KENT',
   KNOX = 'KNOX',
   KU = 'KU',
   LAK = 'LAK',

--- a/website/src/resources/schedules/2020.json
+++ b/website/src/resources/schedules/2020.json
@@ -519,7 +519,7 @@
     "coverage": ["ABC"],
     "highlightsYouTubeVideoId": "TMNfTtoqpkE",
     "location": {
-      "city": "Durham",
+      "city": "Chapel Hill",
       "state": "NC",
       "stadium": "Kenan Memorial Stadium",
       "coordinates": [35.906851, -79.048108]

--- a/website/src/resources/schedules/2022.json
+++ b/website/src/resources/schedules/2022.json
@@ -196,8 +196,8 @@
     "location": {
       "city": "Chapel Hill",
       "state": "NC",
-      "stadium": "Allegiant Stadium",
-      "coordinates": [36.090329, -115.183365]
+      "stadium": "Kenan Memorial Stadium",
+      "coordinates": [35.906944, -79.047778]
     },
     "opponentId": "UNC",
     "espnGameId": 401404126,
@@ -264,8 +264,8 @@
     "location": {
       "city": "Las Vegas",
       "state": "NV",
-      "stadium": "Kenan Memorial Stadium",
-      "coordinates": [35.906944, -79.047778]
+      "stadium": "Allegiant Stadium",
+      "coordinates": [36.090329, -115.183365]
     },
     "opponentId": "BYU",
     "espnGameId": 401404127,

--- a/website/src/resources/schedules/2026.json
+++ b/website/src/resources/schedules/2026.json
@@ -29,7 +29,7 @@
     "isHomeGame": false,
     "date": "10/03/2026",
     "location": {
-      "city": "Durham",
+      "city": "Chapel Hill",
       "state": "NC",
       "stadium": "Kenan Memorial Stadium",
       "coordinates": [35.906851, -79.048108]

--- a/website/src/resources/schedules/2027.json
+++ b/website/src/resources/schedules/2027.json
@@ -12,7 +12,7 @@
     "opponentId": "MSU"
   },
   {"isHomeGame": true, "date": "09/25/2027", "opponentId": "AUB"},
-  {"isHomeGame": true, "date": "10/02/2027", "opponentId": "GT"},
+  {"isHomeGame": true, "date": "10/02/2027", "opponentId": "KENT"},
   {
     "isHomeGame": false,
     "date": "10/09/2027",
@@ -24,10 +24,9 @@
       "coordinates": [35.226206, -80.852917]
     }
   },
-  {"isHomeGame": true, "date": "11/06/2027", "opponentId": "VT"},
   {
     "isHomeGame": false,
-    "date": "11/13/2027",
+    "date": "10/30/2027",
     "location": {
       "city": "Clemson",
       "state": "SC",
@@ -36,7 +35,21 @@
     },
     "opponentId": "CLEM"
   },
+  {"isHomeGame": true, "date": "11/06/2027", "opponentId": "VT"},
   {"isHomeGame": true, "date": "11/20/2027", "opponentId": "NAVY"},
+  {
+    "isHomeGame": false,
+    "date": "11/27/2027",
+    "location": {
+      "city": "Stanford",
+      "state": "CA",
+      "stadium": "Stanford Stadium",
+      "coordinates": [37.434444, -122.161111]
+    },
+    "opponentId": "STAN"
+  },
+  {"isHomeGame": true, "date": "TBD", "opponentId": "BYU"},
+  {"isHomeGame": true, "date": "TBD", "opponentId": "GT"},
   {
     "isHomeGame": false,
     "date": "TBD",
@@ -47,16 +60,5 @@
       "coordinates": [35.995208, -78.941782]
     },
     "opponentId": "DUKE"
-  },
-  {
-    "isHomeGame": false,
-    "date": "TBD",
-    "location": {
-      "city": "Winston-Salem",
-      "state": "NC",
-      "stadium": "Allegacy Stadium",
-      "coordinates": [36.13015, -80.254258]
-    },
-    "opponentId": "WAKE"
   }
 ]

--- a/website/src/resources/schedules/2028.json
+++ b/website/src/resources/schedules/2028.json
@@ -12,6 +12,8 @@
     },
     "opponentId": "PUR"
   },
+  {"isHomeGame": true, "date": "10/07/2028", "opponentId": "CLEM"},
+  {"isHomeGame": true, "date": "10/14/2028", "opponentId": "STAN"},
   {
     "isHomeGame": false,
     "date": "10/28/2028",
@@ -34,7 +36,6 @@
     },
     "opponentId": "VT"
   },
-  {"isHomeGame": true, "date": "11/11/2028", "opponentId": "CLEM"},
   {
     "isHomeGame": false,
     "date": "11/18/2028",

--- a/website/src/resources/schedules/2029.json
+++ b/website/src/resources/schedules/2029.json
@@ -33,7 +33,17 @@
     },
     "opponentId": "NCST"
   },
-  {"isHomeGame": true, "date": "11/03/2029", "opponentId": "GT"},
+  {
+    "isHomeGame": false,
+    "date": "11/03/2029",
+    "location": {
+      "city": "Clemson",
+      "state": "SC",
+      "stadium": "Clemson Memorial Stadium",
+      "coordinates": [34.678643, -82.84322]
+    },
+    "opponentId": "CLEM"
+  },
   {
     "isHomeGame": false,
     "date": "11/10/2029",
@@ -46,6 +56,8 @@
     "opponentId": "FSU"
   },
   {"isHomeGame": true, "date": "TBD", "opponentId": "WAKE"},
+  {"isHomeGame": true, "date": "TBD", "opponentId": "NAVY"},
+  {"isHomeGame": true, "date": "TBD", "opponentId": "GT"},
   {
     "isHomeGame": false,
     "date": "TBD",
@@ -56,17 +68,5 @@
       "coordinates": [43.036062, -76.136434]
     },
     "opponentId": "SYR"
-  },
-  {"isHomeGame": true, "date": "TBD", "opponentId": "NAVY"},
-  {
-    "isHomeGame": false,
-    "date": "TBD",
-    "location": {
-      "city": "Clemson",
-      "state": "SC",
-      "stadium": "Clemson Memorial Stadium",
-      "coordinates": [34.678643, -82.84322]
-    },
-    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2030.json
+++ b/website/src/resources/schedules/2030.json
@@ -11,6 +11,7 @@
     },
     "opponentId": "BAMA"
   },
+  {"isHomeGame": true, "date": "10/19/2030", "opponentId": "CLEM"},
   {
     "isHomeGame": false,
     "date": "11/02/2030",
@@ -46,6 +47,5 @@
       "coordinates": [38.985, -76.507]
     },
     "opponentId": "NAVY"
-  },
-  {"isHomeGame": true, "date": "TBD", "opponentId": "CLEM"}
+  }
 ]

--- a/website/src/resources/schedules/2031.json
+++ b/website/src/resources/schedules/2031.json
@@ -1,15 +1,4 @@
 [
-  {
-    "isHomeGame": false,
-    "date": "09/01/2031",
-    "location": {
-      "city": "Clemson",
-      "state": "SC",
-      "stadium": "Clemson Memorial Stadium",
-      "coordinates": [34.678643, -82.84322]
-    },
-    "opponentId": "CLEM"
-  },
   {"isHomeGame": true, "date": "09/13/2031", "opponentId": "USF"},
   {
     "isHomeGame": false,
@@ -26,16 +15,17 @@
     "isHomeGame": false,
     "date": "10/11/2031",
     "location": {
-      "city": "Charlottesville",
-      "state": "VA",
-      "stadium": "Scott Stadium",
-      "coordinates": [38.031255, -78.513484]
+      "city": "Clemson",
+      "state": "SC",
+      "stadium": "Clemson Memorial Stadium",
+      "coordinates": [34.678643, -82.84322]
     },
-    "opponentId": "UVA"
+    "opponentId": "CLEM"
   },
   {"isHomeGame": true, "date": "11/15/2031", "opponentId": "FLA"},
   {"isHomeGame": true, "date": "11/22/2031", "opponentId": "NCST"},
   {"isHomeGame": true, "date": "TBD", "opponentId": "MIAMI"},
+  {"isHomeGame": true, "date": "TBD", "opponentId": "NAVY"},
   {
     "isHomeGame": false,
     "date": "TBD",
@@ -47,16 +37,26 @@
     },
     "opponentId": "PITT"
   },
-  {"isHomeGame": true, "date": "TBD", "opponentId": "NAVY"},
   {
     "isHomeGame": false,
     "date": "TBD",
     "location": {
-      "city": "Durham",
+      "city": "Chapel Hill",
       "state": "NC",
       "stadium": "Kenan Memorial Stadium",
       "coordinates": [35.906851, -79.048108]
     },
     "opponentId": "UNC"
+  },
+  {
+    "isHomeGame": false,
+    "date": "TBD",
+    "location": {
+      "city": "Charlottesville",
+      "state": "VA",
+      "stadium": "Scott Stadium",
+      "coordinates": [38.031255, -78.513484]
+    },
+    "opponentId": "UVA"
   }
 ]

--- a/website/src/resources/schedules/2032.json
+++ b/website/src/resources/schedules/2032.json
@@ -10,6 +10,7 @@
     },
     "opponentId": "FLA"
   },
+  {"isHomeGame": true, "date": "10/16/2032", "opponentId": "CLEM"},
   {
     "isHomeGame": false,
     "date": "10/30/2032",
@@ -45,6 +46,5 @@
       "coordinates": [38.985, -76.507]
     },
     "opponentId": "NAVY"
-  },
-  {"isHomeGame": true, "date": "TBD", "opponentId": "CLEM"}
+  }
 ]

--- a/website/src/resources/schedules/2033.json
+++ b/website/src/resources/schedules/2033.json
@@ -21,6 +21,17 @@
     },
     "opponentId": "DUKE"
   },
+  {
+    "isHomeGame": false,
+    "date": "10/15/2033",
+    "location": {
+      "city": "Clemson",
+      "state": "SC",
+      "stadium": "Clemson Memorial Stadium",
+      "coordinates": [34.678643, -82.84322]
+    },
+    "opponentId": "CLEM"
+  },
   {"isHomeGame": true, "date": "11/05/2033", "opponentId": "VT"},
   {"isHomeGame": true, "date": "TBD", "opponentId": "PITT"},
   {
@@ -44,16 +55,5 @@
       "coordinates": [38.206123, -85.759065]
     },
     "opponentId": "LOU"
-  },
-  {
-    "isHomeGame": false,
-    "date": "TBD",
-    "location": {
-      "city": "Clemson",
-      "state": "SC",
-      "stadium": "Clemson Memorial Stadium",
-      "coordinates": [34.678643, -82.84322]
-    },
-    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2034.json
+++ b/website/src/resources/schedules/2034.json
@@ -1,5 +1,6 @@
 [
   {"isHomeGame": true, "date": "09/02/2034", "opponentId": "MICH"},
+  {"isHomeGame": true, "date": "10/14/2034", "opponentId": "CLEM"},
   {
     "isHomeGame": false,
     "date": "10/26/2034",
@@ -11,7 +12,6 @@
     },
     "opponentId": "MIAMI"
   },
-  {"isHomeGame": true, "date": "11/11/2034", "opponentId": "CLEM"},
   {"isHomeGame": true, "date": "11/18/2034", "opponentId": "UVA"},
   {"isHomeGame": true, "date": "TBD", "opponentId": "SYR"},
   {

--- a/website/src/resources/schedules/2035.json
+++ b/website/src/resources/schedules/2035.json
@@ -12,6 +12,17 @@
   },
   {
     "isHomeGame": false,
+    "date": "10/27/2035",
+    "location": {
+      "city": "Clemson",
+      "state": "SC",
+      "stadium": "Clemson Memorial Stadium",
+      "coordinates": [34.678643, -82.84322]
+    },
+    "opponentId": "CLEM"
+  },
+  {
+    "isHomeGame": false,
     "date": "11/10/2035",
     "location": {
       "city": "Raleigh",
@@ -33,16 +44,5 @@
       "coordinates": [38.206123, -85.759065]
     },
     "opponentId": "LOU"
-  },
-  {
-    "isHomeGame": false,
-    "date": "TBD",
-    "location": {
-      "city": "Clemson",
-      "state": "SC",
-      "stadium": "Clemson Memorial Stadium",
-      "coordinates": [34.678643, -82.84322]
-    },
-    "opponentId": "CLEM"
   }
 ]

--- a/website/src/resources/schedules/2036.json
+++ b/website/src/resources/schedules/2036.json
@@ -22,7 +22,7 @@
     "opponentId": "GT"
   },
   {"isHomeGame": true, "date": "10/04/2036", "opponentId": "FSU"},
+  {"isHomeGame": true, "date": "10/18/2036", "opponentId": "CLEM"},
   {"isHomeGame": true, "date": "11/01/2036", "opponentId": "PITT"},
-  {"isHomeGame": true, "date": "11/08/2036", "opponentId": "UNC"},
-  {"isHomeGame": true, "date": "TBD", "opponentId": "CLEM"}
+  {"isHomeGame": true, "date": "11/08/2036", "opponentId": "UNC"}
 ]

--- a/website/src/resources/schedules/2037.json
+++ b/website/src/resources/schedules/2037.json
@@ -1,7 +1,8 @@
 [
+  {"isHomeGame": true, "date": "10/03/2037", "opponentId": "NCST"},
   {
     "isHomeGame": false,
-    "date": "09/26/2037",
+    "date": "10/31/2037",
     "location": {
       "city": "Clemson",
       "state": "SC",
@@ -10,7 +11,6 @@
     },
     "opponentId": "CLEM"
   },
-  {"isHomeGame": true, "date": "10/03/2037", "opponentId": "NCST"},
   {"isHomeGame": true, "date": "TBD", "opponentId": "MIAMI"},
   {
     "isHomeGame": false,

--- a/website/src/resources/schedules/2038.json
+++ b/website/src/resources/schedules/2038.json
@@ -1,1 +1,1 @@
-[{"isHomeGame": true, "date": "TBD", "opponentId": "CLEM"}]
+[{"isHomeGame": true, "date": "10/16/2038", "opponentId": "CLEM"}]

--- a/website/src/resources/teams.json
+++ b/website/src/resources/teams.json
@@ -97,6 +97,13 @@
   "IOWA": {"name": "Iowa", "nickname": "Hawkeyes", "color": "#f9cb46", "espnId": 2294},
   "ISU": {"name": "Iowa State", "nickname": "Cyclones", "color": "#83152e", "espnId": 66},
   "KAL": {"name": "Kalamazoo", "nickname": "Fighting Hornets", "color": "#de6e37"},
+  "KENT": {
+    "name": "Kent State",
+    "shortName": "Kent St",
+    "nickname": "Golden Flashes",
+    "color": "#003976",
+    "espnId": 2309
+  },
   "KNOX": {"name": "Knox", "nickname": "Prairie Fire", "color": "#eeab41"},
   "KU": {"name": "Kansas", "nickname": "Jayhawks", "color": "#256aad", "espnId": 2305},
   "LIL": {


### PR DESCRIPTION
## Summary

Updates Notre Dame schedule data through 2038, including newly announced Clemson dates, future ACC/opponent adjustments, and Kent State team metadata for the 2027 schedule.

Also regenerates the static sitemap so the added and expanded season/game pages are discoverable.

## Test plan

- Regenerated `website/public/sitemap.xml`
- Review schedule/resource diffs for updated dates, opponents, and locations